### PR TITLE
Fix build.yaml

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 include:
-  - board: nice_nano@2.0.0
+  - board: nice_nano@2.0.0//zmk
     shield: fuji44_left
-  - board: nice_nano@2.0.0
+  - board: nice_nano@2.0.0//zmk
     shield: fuji44_right
-  - board: nice_nano@2.0.0
+  - board: nice_nano@2.0.0//zmk
     shield: settings_reset


### PR DESCRIPTION
Билд перестал тянуть нужные зависимости по умолчанию с февраля 2026г. 
Это фикс-коммит.
На основе этого решения: https://github.com/zmkfirmware/zmk/issues/3244#issuecomment-3910027197

https://fosstodon.org/@zmk/116056377445281541

